### PR TITLE
Fix/Wallet connection reload

### DIFF
--- a/frontend/src/app/(pages)/agents/[agentID]/page.tsx
+++ b/frontend/src/app/(pages)/agents/[agentID]/page.tsx
@@ -19,12 +19,14 @@ import {
 import {
     adminAccessAtom,
     currentAgentNameAtom,
-    selectedAgentTabAtom
+    selectedAgentTabAtom,
+    walletConnectedAtom
 } from '@app/store/localStore';
 
 export default function AgentPageById() {
     const [, setCurrentAgentName] = useAtom(currentAgentNameAtom);
     const [adminAccess] = useAtom(adminAccessAtom);
+    const [walletConnected] = useAtom(walletConnectedAtom);
     const [selectedTab] = useAtom(selectedAgentTabAtom);
     useEffect(() => {
         setCurrentAgentName(agent?.name || '');
@@ -56,11 +58,11 @@ export default function AgentPageById() {
                 </BreadcrumbList>
             </Breadcrumb>
             <div className={'flex h-full min-h-[600px] w-full gap-4 '}>
-                <AgentTabSection enableEdit={adminAccess} />
+                <AgentTabSection enableEdit={adminAccess && walletConnected} />
                 <AgentTabContent
                     agent={agent}
                     agentLoading={agentLoading}
-                    enableEdit={adminAccess}
+                    enableEdit={adminAccess && walletConnected}
                 />
             </div>
         </div>

--- a/frontend/src/app/(pages)/agents/page.tsx
+++ b/frontend/src/app/(pages)/agents/page.tsx
@@ -23,13 +23,11 @@ import { Skeleton } from '@app/components/shadcn/ui/skeleton';
 import {
     adminAccessAtom,
     agentCreatedAtom,
-    walletApiAtom,
     walletConnectedAtom
 } from '@app/store/localStore';
 
 export default function AgentsPage() {
     const [agentCreated, setAgentCreated] = useAtom(agentCreatedAtom);
-    const [walletApi] = useAtom(walletApiAtom);
     const [adminAccess] = useAtom(adminAccessAtom);
     const [walletConnected] = useAtom(walletConnectedAtom);
 
@@ -99,7 +97,7 @@ export default function AgentsPage() {
                         variant="primary"
                         className={cn(
                             'h-[36px] w-[145px]',
-                            walletApi && adminAccess ? '' : '!hidden'
+                            walletConnected && adminAccess ? '' : '!hidden'
                         )}
                     >
                         Create Agent

--- a/frontend/src/app/(pages)/agents/page.tsx
+++ b/frontend/src/app/(pages)/agents/page.tsx
@@ -20,10 +20,15 @@ import { cn } from '@app/components/lib/utils';
 import AgentCard from '@app/components/molecules/AgentCard';
 import { SuccessToast } from '@app/components/molecules/CustomToasts';
 import { Skeleton } from '@app/components/shadcn/ui/skeleton';
-import { adminAccessAtom, agentCreatedAtom } from '@app/store/localStore';
+import {
+    adminAccessAtom,
+    agentCreatedAtom,
+    walletApiAtom
+} from '@app/store/localStore';
 
 export default function AgentsPage() {
     const [agentCreated, setAgentCreated] = useAtom(agentCreatedAtom);
+    const [walletApi] = useAtom(walletApiAtom);
     const [adminAccess] = useAtom(adminAccessAtom);
 
     const {
@@ -92,7 +97,7 @@ export default function AgentsPage() {
                         variant="primary"
                         className={cn(
                             'h-[36px] w-[145px]',
-                            adminAccess ? '' : '!hidden'
+                            walletApi && adminAccess ? '' : '!hidden'
                         )}
                     >
                         Create Agent

--- a/frontend/src/app/(pages)/agents/page.tsx
+++ b/frontend/src/app/(pages)/agents/page.tsx
@@ -23,13 +23,15 @@ import { Skeleton } from '@app/components/shadcn/ui/skeleton';
 import {
     adminAccessAtom,
     agentCreatedAtom,
-    walletApiAtom
+    walletApiAtom,
+    walletConnectedAtom
 } from '@app/store/localStore';
 
 export default function AgentsPage() {
     const [agentCreated, setAgentCreated] = useAtom(agentCreatedAtom);
     const [walletApi] = useAtom(walletApiAtom);
     const [adminAccess] = useAtom(adminAccessAtom);
+    const [walletConnected] = useAtom(walletConnectedAtom);
 
     const {
         data: agents,
@@ -120,7 +122,7 @@ export default function AgentsPage() {
                                 functionCount={0}
                                 key={index}
                                 refetchData={refetch}
-                                enableEdit={adminAccess}
+                                enableEdit={adminAccess && walletConnected}
                             />
                         ))
                     ) : (

--- a/frontend/src/app/(pages)/my-agent/page.tsx
+++ b/frontend/src/app/(pages)/my-agent/page.tsx
@@ -2,9 +2,12 @@
 
 import { useEffect } from 'react';
 
+import { useRouter } from 'next/navigation';
+
 import { IAgent, fetchMyAgent } from '@api/agents';
 import { useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
+import Cookies from 'js-cookie';
 
 import AgentTabSection from '@app/components/Agent/AgentTab';
 import AgentTabContent from '@app/components/Agent/AgentTabContent';
@@ -15,8 +18,11 @@ import {
     BreadcrumbSeparator
 } from '@app/components/atoms/Breadcrumb';
 import { walletApiAtom } from '@app/store/localStore';
-import { currentAgentNameAtom } from '@app/store/localStore';
-import { selectedAgentTabAtom } from '@app/store/localStore';
+import {
+    adminAccessAtom,
+    currentAgentNameAtom,
+    selectedAgentTabAtom
+} from '@app/store/localStore';
 
 export default function MyAgentPage() {
     const { data: agent, isLoading: agentLoading } = useQuery<IAgent>({
@@ -25,6 +31,7 @@ export default function MyAgentPage() {
     });
 
     const [, setCurrentAgentName] = useAtom(currentAgentNameAtom);
+    const [adminAccess] = useAtom(adminAccessAtom);
     const [selectedTab] = useAtom(selectedAgentTabAtom);
     useEffect(() => {
         setCurrentAgentName(agent?.name || '');
@@ -32,16 +39,14 @@ export default function MyAgentPage() {
 
     const [walletApi] = useAtom(walletApiAtom);
 
-    if (walletApi === null) {
-        return (
-            <div className="mt-[30%] flex h-full items-center justify-center text-brand-Gray-300">
-                <div className="text-center">
-                    <p>Active Wallet Connection Missing!</p>
-                    <p>Please connect your Wallet . . .</p>
-                </div>
-            </div>
-        );
-    }
+    const router = useRouter();
+
+    useEffect(() => {
+        if (Cookies.get('access_token') === null || walletApi === null || adminAccess) {
+            router.push('/');
+        }
+    }, []);
+
     return (
         <div className={'flex flex-col gap-4'}>
             <Breadcrumb>

--- a/frontend/src/app/(pages)/my-agent/page.tsx
+++ b/frontend/src/app/(pages)/my-agent/page.tsx
@@ -17,7 +17,7 @@ import {
     BreadcrumbList,
     BreadcrumbSeparator
 } from '@app/components/atoms/Breadcrumb';
-import { walletApiAtom } from '@app/store/localStore';
+import { walletConnectedAtom } from '@app/store/localStore';
 import {
     adminAccessAtom,
     currentAgentNameAtom,
@@ -37,12 +37,16 @@ export default function MyAgentPage() {
         setCurrentAgentName(agent?.name || '');
     });
 
-    const [walletApi] = useAtom(walletApiAtom);
+    const [walletConnected] = useAtom(walletConnectedAtom);
 
     const router = useRouter();
 
     useEffect(() => {
-        if (Cookies.get('access_token') === null || walletApi === null || adminAccess) {
+        if (
+            Cookies.get('access_token') === null ||
+            walletConnected === null ||
+            adminAccess
+        ) {
             router.push('/');
         }
     }, []);

--- a/frontend/src/app/(pages)/templates/TemplatesContainer.tsx
+++ b/frontend/src/app/(pages)/templates/TemplatesContainer.tsx
@@ -4,7 +4,7 @@ import { useAtom } from 'jotai';
 
 import { ITemplate } from '@app/app/api/templates';
 import TemplateCard from '@app/components/molecules/TemplateCard';
-import { adminAccessAtom } from '@app/store/localStore';
+import { adminAccessAtom, walletConnectedAtom } from '@app/store/localStore';
 
 interface TemplatesContainerProps {
     templates: ITemplate[];
@@ -12,6 +12,7 @@ interface TemplatesContainerProps {
 
 export default function TemplatesContainer({ templates }: TemplatesContainerProps) {
     const [adminAccess] = useAtom(adminAccessAtom);
+    const [walletConnected] = useAtom(walletConnectedAtom);
 
     return (
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2  lg:grid-cols-3 xl:grid-cols-4 4xl:grid-cols-5">
@@ -20,7 +21,7 @@ export default function TemplatesContainer({ templates }: TemplatesContainerProp
                     template={item}
                     templateTrigger={'null'}
                     key={index}
-                    enableEdit={adminAccess}
+                    enableEdit={adminAccess && walletConnected}
                 />
             ))}
         </div>

--- a/frontend/src/app/(pages)/templates/[templateId]/edit/page.tsx
+++ b/frontend/src/app/(pages)/templates/[templateId]/edit/page.tsx
@@ -20,7 +20,7 @@ import { ErrorToast, SuccessToast } from '@app/components/molecules/CustomToasts
 import TemplateConfigurations from '@app/components/molecules/TemplateConfigurations';
 import UpdateTemplateFunctionModal from '@app/components/molecules/UpdateTemplateFunctionModal';
 import { Dialog, DialogContent } from '@app/components/shadcn/dialog';
-import { adminAccessAtom } from '@app/store/localStore';
+import { adminAccessAtom, walletConnectedAtom } from '@app/store/localStore';
 
 const EditTemplateCard = () => {
     const params = useParams();
@@ -48,6 +48,7 @@ const EditTemplateCard = () => {
         Array<ITemplateConfiguration>
     >([]);
     const [adminAccess] = useAtom(adminAccessAtom);
+    const [walletConnected] = useAtom(walletConnectedAtom);
 
     const [templateDetails, setTemplateDetails] = useState<{
         name: string;
@@ -123,7 +124,7 @@ const EditTemplateCard = () => {
                             className={
                                 'w-11/12 rounded border border-brand-Black-100/80 px-2 py-1'
                             }
-                            disabled={!adminAccess}
+                            disabled={!adminAccess || !walletConnected}
                         />
                     </div>
                     <div className={'flex flex-col gap-1'}>
@@ -138,7 +139,7 @@ const EditTemplateCard = () => {
                                     description: e.target.value
                                 })
                             }
-                            disabled={!adminAccess}
+                            disabled={!adminAccess || !walletConnected}
                             type="text"
                             className={
                                 'w-11/12 rounded border border-brand-Black-100/80 px-2 py-1'
@@ -151,7 +152,7 @@ const EditTemplateCard = () => {
                     <div
                         className={cn(
                             'cursor-pointer rounded p-1 hover:bg-gray-200',
-                            adminAccess ? '' : 'hidden'
+                            adminAccess && walletConnected ? '' : 'hidden'
                         )}
                         onClick={() => setOpenDialog(true)}
                     >
@@ -186,7 +187,12 @@ const EditTemplateCard = () => {
                     </DialogContent>
                 </Dialog>
 
-                <div className={cn('flex justify-end', adminAccess ? '' : '!hidden')}>
+                <div
+                    className={cn(
+                        'flex justify-end',
+                        adminAccess && walletConnected ? '' : '!hidden'
+                    )}
+                >
                     <Button onClick={() => handleOnClickUpdate()}>Update</Button>
                 </div>
             </div>

--- a/frontend/src/app/(pages)/templates/page.tsx
+++ b/frontend/src/app/(pages)/templates/page.tsx
@@ -19,7 +19,11 @@ import { SearchField } from '@app/components/atoms/SearchField';
 import { cn } from '@app/components/lib/utils';
 import { SuccessToast } from '@app/components/molecules/CustomToasts';
 import { Skeleton } from '@app/components/shadcn/ui/skeleton';
-import { adminAccessAtom, templateCreatedAtom } from '@app/store/localStore';
+import {
+    adminAccessAtom,
+    templateCreatedAtom,
+    walletApiAtom
+} from '@app/store/localStore';
 
 import TemplatesContainer from './TemplatesContainer';
 
@@ -32,6 +36,7 @@ export default function TemplatesPage() {
     const [templateCreated, setTemplateCreated] = useAtom(templateCreatedAtom);
     const [filteredTemplates, setFilteredTemplates] = useState<ITemplate[]>([]);
     const [adminAccess] = useAtom(adminAccessAtom);
+    const [walletApi] = useAtom(walletApiAtom);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
@@ -83,7 +88,7 @@ export default function TemplatesPage() {
                         variant="primary"
                         className={cn(
                             'h-[36px] w-[145px]',
-                            adminAccess ? '' : '!hidden'
+                            walletApi && adminAccess ? '' : '!hidden'
                         )}
                     >
                         Create Template

--- a/frontend/src/app/(pages)/templates/page.tsx
+++ b/frontend/src/app/(pages)/templates/page.tsx
@@ -36,7 +36,7 @@ export default function TemplatesPage() {
     const [templateCreated, setTemplateCreated] = useAtom(templateCreatedAtom);
     const [filteredTemplates, setFilteredTemplates] = useState<ITemplate[]>([]);
     const [adminAccess] = useAtom(adminAccessAtom);
-    const [walletApi] = useAtom(walletApiAtom);
+    const [walletConnected] = useAtom(walletApiAtom);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
@@ -88,7 +88,7 @@ export default function TemplatesPage() {
                         variant="primary"
                         className={cn(
                             'h-[36px] w-[145px]',
-                            walletApi && adminAccess ? '' : '!hidden'
+                            walletConnected && adminAccess ? '' : '!hidden'
                         )}
                     >
                         Create Template

--- a/frontend/src/components/Auth/WalletSignInDialog.tsx
+++ b/frontend/src/components/Auth/WalletSignInDialog.tsx
@@ -13,7 +13,12 @@ import { OctagonAlert, Wallet } from 'lucide-react';
 import { X } from 'lucide-react';
 
 import { Dialog, DialogContent } from '@app/components/atoms/Dialog';
-import { adminAccessAtom, savedWalletAtom, walletApiAtom } from '@app/store/localStore';
+import {
+    adminAccessAtom,
+    savedWalletAtom,
+    walletApiAtom,
+    walletConnectedAtom
+} from '@app/store/localStore';
 import { generateSignedData } from '@app/utils/auth';
 import { getStakeAddress, listProviders } from '@app/utils/wallet';
 
@@ -34,6 +39,7 @@ export default function WalletSignInDialog({
     const [, setWalletApi] = useAtom(walletApiAtom);
     const [, setSavedWallet] = useAtom(savedWalletAtom);
     const [, setAdminAcess] = useAtom(adminAccessAtom);
+    const [, setWalletConencted] = useAtom(walletConnectedAtom);
 
     const [dialogOpen, setDialogOpen] = useState<boolean>(false);
 
@@ -62,9 +68,9 @@ export default function WalletSignInDialog({
                     setWalletApi(enabledApi);
                     setSavedWallet({
                         name: wallet.name,
-                        stakeAddress: walletStakeAddress,
-                        connected: true
+                        stakeAddress: walletStakeAddress
                     });
+                    setWalletConencted(true);
                     setConnectingWallet(false);
 
                     router.push('/');
@@ -77,7 +83,8 @@ export default function WalletSignInDialog({
         } catch (error: any) {
             ErrorToast('Unable to Sign In. Please try again');
             setConnectingWallet(false);
-            setSavedWallet({ name: null, stakeAddress: null, connected: false });
+            setSavedWallet({ name: null, stakeAddress: null });
+            setWalletConencted(false);
         }
     }
 

--- a/frontend/src/components/Auth/WalletSignInDialog.tsx
+++ b/frontend/src/components/Auth/WalletSignInDialog.tsx
@@ -126,6 +126,12 @@ export default function WalletSignInDialog({
                     if (walletStakeAddress === storedWalletStakeAddress) {
                         setWalletApi(enabledApi);
                         setWalletStakeAddress(walletStakeAddress);
+                    } else {
+                        setWalletApi(null);
+                        setAdminAcess(false);
+                        Cookies.remove('access_token');
+                        localStorage.removeItem('wallet_stake_address');
+                        localStorage.removeItem('wallet_provider');
                     }
                 }
             }

--- a/frontend/src/components/layout/SideNav.tsx
+++ b/frontend/src/components/layout/SideNav.tsx
@@ -10,6 +10,7 @@ import { PATHS } from '@consts';
 import { Typography } from '@mui/material';
 import { useAtom } from 'jotai';
 import Cookies from 'js-cookie';
+import { CIP30Provider } from 'kuber-client/types';
 import { Boxes } from 'lucide-react';
 
 import DashBoardIcon from '@app/components/icons/DashboardIcon';
@@ -185,6 +186,12 @@ export default function SideNav() {
                             <CurrentWalletDiv
                                 address={savedWallet.stakeAddress || ''}
                                 onDisconnect={handleDisconnect}
+                                iconSrc={
+                                    listProviders().find(
+                                        (item: CIP30Provider) =>
+                                            item.name === savedWallet.name
+                                    )?.icon || ''
+                                }
                             />
                         </div>
                     ) : (
@@ -205,11 +212,13 @@ export default function SideNav() {
 function CurrentWalletDiv({
     address,
     className,
-    onDisconnect
+    onDisconnect,
+    iconSrc
 }: {
     address: string;
     className?: string;
     onDisconnect?: any;
+    iconSrc?: string;
 }) {
     return (
         <div
@@ -218,7 +227,10 @@ function CurrentWalletDiv({
                 className
             )}
         >
-            <div className="h3 text-brand-Blue-200">Connected Wallet</div>
+            <div className="flex items-center gap-2">
+                <img src={iconSrc} height={32} width={32}></img>
+                <div className="h3 text-brand-Blue-200">Connected Wallet</div>
+            </div>
             <div>
                 <Typography className="break-all text-xs text-brand-Black-200">
                     {address}

--- a/frontend/src/components/layout/SideNav.tsx
+++ b/frontend/src/components/layout/SideNav.tsx
@@ -19,7 +19,12 @@ import Logo from '@app/components/icons/Logo';
 import LogsIcon from '@app/components/icons/LogsIcon';
 import TemplateIcon from '@app/components/icons/TemplatesIcon';
 import SideNavLink from '@app/components/layout/SideNavLink';
-import { adminAccessAtom, savedWalletAtom, walletApiAtom } from '@app/store/localStore';
+import {
+    adminAccessAtom,
+    savedWalletAtom,
+    walletApiAtom,
+    walletConnectedAtom
+} from '@app/store/localStore';
 import { listProviders } from '@app/utils/wallet';
 import { getStakeAddress } from '@app/utils/wallet';
 
@@ -42,6 +47,7 @@ export default function SideNav() {
     const [dialogOpen, setDialogOpen] = useState(false);
     const [adminAccess, setAdminAcess] = useAtom(adminAccessAtom);
     const [savedWallet, setSavedWallet] = useAtom(savedWalletAtom);
+    const [walletConnected, setWalletConencted] = useAtom(walletConnectedAtom);
 
     const SideNavItems: ISideNavItem[] = [
         {
@@ -92,14 +98,15 @@ export default function SideNav() {
     async function conenctWallet() {
         const prevWalletConnected = await enablePrevWallet();
         if (!prevWalletConnected) {
-            setSavedWallet({ name: null, stakeAddress: null, connected: false });
+            setSavedWallet({ name: null, stakeAddress: null });
             toggleDialog();
         }
     }
 
     function handleDisconnect() {
         setWalletApi(null);
-        setSavedWallet({ name: null, stakeAddress: null, connected: false });
+        setSavedWallet({ name: null, stakeAddress: null });
+        setWalletConencted(false);
         SendLogoutRequest();
         setAdminAcess(false);
         SuccessToast('Wallet Disconnected');
@@ -130,17 +137,18 @@ export default function SideNav() {
                     console.log(savedWallet.stakeAddress);
                     setSavedWallet({
                         name: wallet.name,
-                        stakeAddress: walletStakeAddress,
-                        connected: true
+                        stakeAddress: walletStakeAddress
                     });
                     setWalletApi(enabledApi);
+                    setWalletConencted(true);
                     console.log('Enabled previous wallet');
                     return true;
                 }
             }
         }
         console.log('Failed to enable previous wallet');
-        setSavedWallet({ name: null, stakeAddress: null, connected: false });
+        setSavedWallet({ name: null, stakeAddress: null });
+        setWalletConencted(false);
         setAdminAcess(false);
         setWalletApi(null);
         return false;
@@ -180,7 +188,7 @@ export default function SideNav() {
                             <SideNavLink key={index} Prop={Prop} />
                         ))}
                     </div>
-                    {walletApi !== null && savedWallet.connected ? (
+                    {walletApi !== null && walletConnected ? (
                         <div className="flex flex-col gap-x-2 gap-y-4 px-2 pb-2">
                             <SideNavLink key={1} Prop={MyAgentSideNavItem} />
                             <CurrentWalletDiv

--- a/frontend/src/components/layout/TopNav.tsx
+++ b/frontend/src/components/layout/TopNav.tsx
@@ -5,11 +5,16 @@ import { usePathname } from 'next/navigation';
 import { PATHS } from '@consts';
 import { useAtom } from 'jotai';
 
-import { adminAccessAtom, currentAgentNameAtom } from '@app/store/localStore';
+import {
+    adminAccessAtom,
+    currentAgentNameAtom,
+    walletApiAtom
+} from '@app/store/localStore';
 
 export default function TopNav() {
     const [currentAgentName] = useAtom(currentAgentNameAtom);
     const [adminAcesss] = useAtom(adminAccessAtom);
+    const [walletApi] = useAtom(walletApiAtom);
     const path: string = usePathname();
 
     const PageTitles: { [key: string]: string } = {
@@ -40,7 +45,7 @@ export default function TopNav() {
     return (
         <div className="flex w-[full] items-center justify-between text-sm">
             <span className="h1">{getPageTitle()}</span>
-            {adminAcesss && 'Admin'}
+            {walletApi && adminAcesss && 'Admin'}
         </div>
     );
 }

--- a/frontend/src/components/layout/TopNav.tsx
+++ b/frontend/src/components/layout/TopNav.tsx
@@ -8,13 +8,13 @@ import { useAtom } from 'jotai';
 import {
     adminAccessAtom,
     currentAgentNameAtom,
-    walletApiAtom
+    walletConnectedAtom
 } from '@app/store/localStore';
 
 export default function TopNav() {
     const [currentAgentName] = useAtom(currentAgentNameAtom);
     const [adminAcesss] = useAtom(adminAccessAtom);
-    const [walletApi] = useAtom(walletApiAtom);
+    const [walletConnected] = useAtom(walletConnectedAtom);
     const path: string = usePathname();
 
     const PageTitles: { [key: string]: string } = {
@@ -45,7 +45,7 @@ export default function TopNav() {
     return (
         <div className="flex w-[full] items-center justify-between text-sm">
             <span className="h1">{getPageTitle()}</span>
-            {walletApi && adminAcesss && 'Admin'}
+            {walletConnected && adminAcesss && 'Admin'}
         </div>
     );
 }

--- a/frontend/src/store/localStore.ts
+++ b/frontend/src/store/localStore.ts
@@ -2,6 +2,12 @@ import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { CIP30Instance } from 'kuber-client/types';
 
+interface IWalletInfo {
+    name: string | null;
+    stakeAddress: string | null;
+    connected: boolean;
+}
+
 export const agentCreatedAtom = atom(false);
 
 export const templateCreatedAtom = atom(false);
@@ -18,6 +24,10 @@ export const currentAgentNameAtom = atom('Agent Profile');
 
 export const walletApiAtom = atom<CIP30Instance | null>(null);
 
-export const walletStakeAddressAtom = atom<string | null>(null);
-
 export const adminAccessAtom = atomWithStorage<boolean>('adminAccess', false);
+
+export const savedWalletAtom = atomWithStorage<IWalletInfo>('savedWallet', {
+    name: null,
+    stakeAddress: null,
+    connected: false
+});

--- a/frontend/src/store/localStore.ts
+++ b/frontend/src/store/localStore.ts
@@ -5,7 +5,6 @@ import { CIP30Instance } from 'kuber-client/types';
 interface IWalletInfo {
     name: string | null;
     stakeAddress: string | null;
-    connected: boolean;
 }
 
 export const agentCreatedAtom = atom(false);
@@ -28,6 +27,7 @@ export const adminAccessAtom = atomWithStorage<boolean>('adminAccess', false);
 
 export const savedWalletAtom = atomWithStorage<IWalletInfo>('savedWallet', {
     name: null,
-    stakeAddress: null,
-    connected: false
+    stakeAddress: null
 });
+
+export const walletConnectedAtom = atom<boolean>(false);

--- a/frontend/src/utils/wallet.ts
+++ b/frontend/src/utils/wallet.ts
@@ -1,0 +1,29 @@
+import { CIP30Instance, CIP30Provider } from 'kuber-client/types';
+
+export async function getStakeAddress(wallet: CIP30Instance) {
+    const reward_address = await wallet.getRewardAddresses();
+    if (reward_address.length > 0) {
+        return reward_address[0];
+    }
+    return false;
+}
+
+export function listProviders(): CIP30Provider[] {
+    const pluginMap = new Map();
+    //@ts-ignore
+    if (!window.cardano) {
+        return [];
+    }
+    //@ts-ignore
+    Object.keys(window.cardano).forEach((x) => {
+        //@ts-ignore
+        const plugin: CIP30Provider = window.cardano[x];
+        //@ts-ignore
+        if (plugin.enable && plugin.name) {
+            pluginMap.set(plugin.name, plugin);
+        }
+    });
+    const providers = Array.from(pluginMap.values());
+    // yoroi doesn't work (remove this after yoroi works)
+    return providers.filter((x) => x.name != 'yoroi');
+}


### PR DESCRIPTION
 **Summary**

- Implemented direct sign-in for users with saved wallet information and an access token in the client cookie after page reload.
- Addressed edge cases for admin access when reconnecting after a page reload.
- Redirected regular users away from the My-Agent Page upon wallet disconnection.
- Prompted users to log in again if the wallet provider remains the same but the account changes.

**Additional**

- Added an icon to display the current connected wallet provider.


**How Authentication Works on Reload**

On the client side, two items are stored in Local Storage: one for wallet provider information ( provider name and stake address )  and another to track if the user has admin access. Additionally, a wallet_connected state is maintained to verify if a wallet is active.

When the user logs in, all this information is saved, and wallet_connected is set to true. If the user reloads the page, wallet_connected resets to false. Upon clicking the "Connect Wallet" button, the app checks if the current wallet provider's stake address matches the stored stake address and if the user has a valid authentication cookie. If these conditions are not met, it means the user has changed his active wallet from the provider or signed out intentionally , the user is prompted to log in again. If the conditions meet then the user is directly signed in.

Create/Edit/Delete Components are rendered based on whether admin access is granted and if the wallet is connected.