### PR TITLE
Fix: Convert history log UTC timestamp to Local Time

### DIFF
--- a/frontend/src/components/Agent/AgentLog.tsx
+++ b/frontend/src/components/Agent/AgentLog.tsx
@@ -13,7 +13,7 @@ import {
 } from '@app/app/api/triggerHistory';
 import AgentsIcon from '@app/components/icons/AgentsIcon';
 import { SuccessToast } from '@app/components/molecules/CustomToasts';
-import parseTimestamp from '@app/utils/dateAndTimeUtils';
+import { formatTimestamp } from '@app/utils/dateAndTimeUtils';
 
 import AgentFunctionsDropDown from '../Common/AgentFunctionsDropDown';
 import { Badge } from '../atoms/Badge';
@@ -178,11 +178,7 @@ export const AgentLogCard = ({
                 }
             >
                 <Badge variant={getBadgeVariant()}>{getAgentExecutionStatus()}</Badge>
-                <span className={'text-xs'}>
-                    {parseTimestamp(
-                        history?.timestamp || '2024-06-18T07:07:00.283000+00:00'
-                    )}
-                </span>
+                <span className={'text-xs'}>{formatTimestamp(history.timestamp)}</span>
             </div>
         </div>
     );

--- a/frontend/src/utils/dateAndTimeUtils.ts
+++ b/frontend/src/utils/dateAndTimeUtils.ts
@@ -67,3 +67,17 @@ export function determineCronTabAndSection(cronExpression: string) {
         return determineSection(minute, 'Minute');
     }
 }
+
+export function formatTimestamp(timestamp: string) {
+    const date = new Date(timestamp);
+    const timeString = date.toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+    const dateString = date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+    });
+    return `${timeString} ${dateString}`;
+}


### PR DESCRIPTION
Converted history logs GMT timestamp to local time and formatted accordingly in /logs and /agent/logs.