### PR TITLE
Fix: return false when datetime for agent last active is None

### DIFF
--- a/api/backend/app/services/agent_service.py
+++ b/api/backend/app/services/agent_service.py
@@ -22,7 +22,9 @@ from backend.app.exceptions import HTTPException
 from backend.app.repositories.user_repository import UserRepository
 
 
-def check_if_agent_is_online(last_active: datetime) -> bool:
+def check_if_agent_is_online(last_active: datetime | None) -> bool:
+    if last_active is None:
+        return False
     threshold_time = timedelta(seconds=5)
     time_diff = datetime.now(UTC) - last_active
     if time_diff <= threshold_time:


### PR DESCRIPTION
Agents who were not activated had None as default last active which led to issues when returning agent info from the api.