### PR TITLE
Fix/acess token expiration

### DIFF
--- a/api/backend/app/controllers/auth_router.py
+++ b/api/backend/app/controllers/auth_router.py
@@ -8,6 +8,7 @@ from backend.app.models.user.response_dto import UserResponse
 from backend.app.models.user.user_dto import SignatureDataDto, UserCreateDto
 from backend.config.api_settings import APISettings
 import os
+from datetime import datetime, timedelta, timezone
 
 
 class AuthRouter(Routable):
@@ -40,7 +41,7 @@ class AuthRouter(Routable):
                 value=token,
                 samesite="lax",
                 secure=self.settings.SECURE,
-                expires=None,
+                expires=datetime.now(timezone.utc) + timedelta(15),
                 domain=request.url.hostname,
                 path="/",
             )

--- a/api/backend/app/controllers/auth_router.py
+++ b/api/backend/app/controllers/auth_router.py
@@ -40,7 +40,7 @@ class AuthRouter(Routable):
                 value=token,
                 samesite="lax",
                 secure=self.settings.SECURE,
-                expires=60 * 60 * 24,
+                expires=None,
                 domain=request.url.hostname,
                 path="/",
             )

--- a/frontend/src/components/layout/SideNav.tsx
+++ b/frontend/src/components/layout/SideNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -9,6 +9,7 @@ import { SendLogoutRequest } from '@api/auth';
 import { PATHS } from '@consts';
 import { Typography } from '@mui/material';
 import { useAtom } from 'jotai';
+import cookie from 'js-cookie';
 import { Boxes } from 'lucide-react';
 
 import DashBoardIcon from '@app/components/icons/DashboardIcon';
@@ -85,6 +86,14 @@ export default function SideNav() {
         SuccessToast('Wallet Disconnected');
         router.push('/');
     }
+
+    useEffect(() => {
+        const access_token = cookie.get('access_token');
+        if (access_token === null || access_token === undefined) {
+            setAdminAcess(false);
+            setCurrentConnectedWallet(null);
+        }
+    }, []);
 
     return (
         <>


### PR DESCRIPTION
### Summary

- Set cookie expiry time to None, ensuring the cookie persists until the browser session ends.
- Handle edge case when the access_token cookie is missing: Removes saved wallet information and revokes admin access in such scenarios