### PR TITLE
Perf/TriggerService-ChartQuery

### DIFF
--- a/api/backend/app/controllers/trigger_history_router.py
+++ b/api/backend/app/controllers/trigger_history_router.py
@@ -52,6 +52,6 @@ class TriggerHistory(Routable):
     async def get_trigger_metric(
         self, function_name: Optional[list[str]] = Query(None), agent_id: Optional[str] = None
     ):
-        return await self.trigger_history_service.calculate_trigger_metric(
+        return await self.trigger_history_service.calculate_trigger_metric_by_query(
             function_name=function_name, agent_id=agent_id
         )

--- a/api/backend/app/services/trigger_history_service.py
+++ b/api/backend/app/services/trigger_history_service.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Optional, List, Dict, Any
 
 from fastapi_pagination import Page
 
@@ -9,44 +9,8 @@ from backend.app.models.trigger_history.trigger_history_dto import TriggerHistor
 from backend.app.repositories.trigger_history_repository import TriggerHistoryRepository
 from backend.config.database import prisma_connection
 from backend.app.utils.extras import calculate_change_rate
-
 from datetime import datetime, timezone
-
-
-class TriggerClassifier:
-    # Custom Data structure for Accumulating Transaction Count using TimeStamp.
-    # The append method offsets the index for data accumulation accordingly.
-    def __init__(self, classifier_type) -> None:
-        self.classifier_type = classifier_type
-        classifier_types = ["LASTHOUR", "LAST24HOUR", "LASTWEEK"]
-        assert self.classifier_type in classifier_types
-
-        max_range = None
-        if classifier_type == "LASTHOUR":
-            max_range = 60
-        elif classifier_type == "LAST24HOUR":
-            max_range = 24
-        elif classifier_type == "LASTWEEK":
-            max_range = 7
-
-        self.accumulator = [{"count": 0, "values": {}} for _ in range(max_range)]
-
-    def append(self, timestamp, itemName):
-        today = datetime.now(timezone.utc)
-        time_diff = today - timestamp
-
-        if self.classifier_type == "LASTHOUR":
-            index = int(time_diff.total_seconds() / 60) % 60
-        elif self.classifier_type == "LAST24HOUR":
-            index = int(time_diff.total_seconds() / 3600) % 24
-        elif self.classifier_type == "LASTWEEK":
-            index = time_diff.days % 7
-
-        self.accumulator[index]["count"] += 1
-        if itemName in self.accumulator[index]["values"]:
-            self.accumulator[index]["values"][itemName] += 1
-        else:
-            self.accumulator[index]["values"][itemName] = 1
+from backend.app.models.trigger_history.trigger_history_dto import TriggerHistoryDto
 
 
 class TriggerHistoryService:
@@ -86,71 +50,138 @@ class TriggerHistoryService:
             "unskipped_transactions": unskipped_txs,
         }
 
-    async def calculate_trigger_metric(self, function_name: list[str], agent_id: str):
+    async def calculate_trigger_metric_by_query(self, function_name: list[str], agent_id: str):
+        query = self.format_query(function_name, agent_id)
+        response = {"function_name": function_name}
 
-        successfull_triggers = await self.trigger_history_repo.get_all_triggers_history(
-            agent_id=agent_id,
-            function_name=function_name,
-            status=True,
-            success=True,
-            enable_pagination=False,
-        )
-        unsuccessfull_triggers = await self.trigger_history_repo.get_all_triggers_history(
-            agent_id=agent_id,
-            function_name=function_name,
-            status=True,
-            success=False,
-            enable_pagination=False,
-        )
-        skipeed_triggers = await self.trigger_history_repo.get_all_triggers_history(
-            agent_id=agent_id,
-            function_name=function_name,
-            status=False,
-            success=False,
-            enable_pagination=False,
-        )
-
-        today = datetime.now(timezone.utc)
-        last_hour_successful_triggers = TriggerClassifier("LASTHOUR")
-        last_24hour_successful_triggers = TriggerClassifier("LAST24HOUR")
-        last_week_successful_triggers = TriggerClassifier("LASTWEEK")
-
-        last_day_transactions = 0
-        today_transactions = 0
-        successfull_triggers_dict = {}
-
-        for trigger in successfull_triggers:
-            time_diff = today - trigger.timestamp
-
-            # Check the Time difference / Time passed between today and log timestamp.
-            if time_diff.days < 7:
-                last_week_successful_triggers.append(trigger.timestamp, trigger.functionName)
-                if time_diff.days < 1:
-                    last_24hour_successful_triggers.append(trigger.timestamp, trigger.functionName)
-                    if (time_diff.seconds / 60) < 60:
-                        last_hour_successful_triggers.append(trigger.timestamp, trigger.functionName)
-
-            # For calculating fluctuation rate
-            if time_diff.days < 3 and time_diff.days >= 1:
-                last_day_transactions += 1
-            elif time_diff.days < 1:
-                today_transactions += 1
-
-        # for classifying succcesfull triggers
-        for trigger in successfull_triggers:
-            if trigger.functionName in successfull_triggers_dict:
-                successfull_triggers_dict[trigger.functionName] += 1
-            else:
-                successfull_triggers_dict[trigger.functionName] = 1
-
-        response = {
-            "function_name": function_name,
-            "no_of_successful_triggers": len(successfull_triggers),
-            "no_of_unsuccessful_triggers": len(unsuccessfull_triggers),
-            "no_of_skipped_triggers": len(skipeed_triggers),
-            "last_hour_successful_triggers": last_hour_successful_triggers.accumulator,
-            "last_24hour_successful_triggers": last_24hour_successful_triggers.accumulator,
-            "last_week_successful_triggers": last_week_successful_triggers.accumulator,
-            "today_fluctuation_rate": calculate_change_rate(last_day_transactions, today_transactions),
+        # for different trigger results length
+        trigger_result_types = {
+            "no_of_successful_triggers": {"status": True, "success": True},
+            "no_of_unsuccessful_triggers": {"status": True, "success": False},
+            "no_of_skipped_triggers": {"status": False, "success": False},
         }
+        for key, value in trigger_result_types.items():
+            filters = {**value}
+            triggers_len = await self.db.prisma.triggerhistory.count(where=query | filters)
+            response[key] = triggers_len
+
+        raw_successfull_triggers_last_hour = await self.db.prisma.query_raw(
+            self.build_query("last_hour", agent_id, function_name)
+        )
+
+        raw_successful_triggers_last_24_hours = await self.db.prisma.query_raw(
+            self.build_query("last_24_hours", agent_id, function_name)
+        )
+
+        raw_successful_triggers_last_7_days = await self.db.prisma.query_raw(
+            self.build_query("last_7_days", agent_id, function_name)
+        )
+
+        fluctuation_rate = await self.get_fluctuation_rate(agent_id=agent_id, function_name=function_name)
+        # Format results to match the expected format
+        response.update(
+            {
+                "last_hour_successful_triggers": self.process_chart_data(raw_successfull_triggers_last_hour, 60),
+                "last_24hour_successful_triggers": self.process_chart_data(raw_successful_triggers_last_24_hours, 24),
+                "last_week_successful_triggers": self.process_chart_data(raw_successful_triggers_last_7_days, 7),
+                "today_fluctuation_rate": fluctuation_rate,
+            }
+        )
         return response
+
+    def format_query(self, function_name: list[str] = None, agent_id: str = None):
+        query = {}
+        if agent_id is not None:
+            query["agentId"] = agent_id
+        if function_name is not None:
+            query["functionName"] = {"in": function_name}
+        return query
+
+    def process_chart_data(self, raw_data: List[Dict[str, Any]], max_range: int) -> List[Dict[str, Any]]:
+        result = [{"count": 0, "values": {}} for _ in range(max_range)]
+        now = datetime.now(timezone.utc)
+        for item in raw_data:
+            timestamp_str = item.get("minute") or item.get("hour") or item.get("day")
+            if timestamp_str:
+                timestamp = datetime.fromisoformat(timestamp_str).replace(tzinfo=timezone.utc)
+                if max_range == 60:  # Last hour
+                    index = int((now - timestamp).total_seconds() / 60) % 60
+                elif max_range == 24:  # Last 24 hours
+                    index = int((now - timestamp).total_seconds() / 3600) % 24
+                elif max_range == 7:  # Last 7 days
+                    index = (now.date() - timestamp.date()).days % 7
+                else:
+                    continue
+                result[index]["count"] += item["successful_triggers"]
+                result[index]["values"][item.get("functionName", "Unknown")] = item["successful_triggers"]
+        return result
+
+    def build_query(
+        self, time_interval: str, agent_id: Optional[str] = None, function_name: Optional[List[str]] = None
+    ) -> str:
+        if time_interval not in ["last_hour", "last_24_hours", "last_7_days"]:
+            raise ValueError("Invalid time interval. Must be 'last_hour', 'last_24_hours', or 'last_7_days'.")
+        time_intervals = {
+            "last_hour": "NOW() - INTERVAL '60 minutes'",
+            "last_24_hours": "NOW() - INTERVAL '24 hours'",
+            "last_7_days": "NOW() - INTERVAL '7 days'",
+        }
+        # Base query
+        query = f"""
+            SELECT
+                date_trunc('minute', "timestamp") AS minute,
+                "functionName",
+                COUNT(*) AS successful_triggers
+            FROM
+                "TriggerHistory"
+            WHERE
+                status = true
+                AND success = true
+                AND "timestamp" >= {time_intervals[time_interval]}
+        """
+        # Add Agend id filter and function filter if required
+        if agent_id:
+            query += f" AND \"agentId\" = '{agent_id}'"
+        if function_name:
+            function_names = ", ".join([f"'{fn}'" for fn in function_name])
+            query += f' AND "functionName" IN ({function_names})'
+
+        # Add group by and order by clauses
+        query += """
+            GROUP BY
+                minute, "functionName"
+            ORDER BY
+                minute DESC, "functionName";
+        """
+        return query
+
+    async def get_fluctuation_rate(self, agent_id: Optional[str] = None, function_name: Optional[List[str]] = None):
+        now = datetime.now(timezone.utc)
+        start_of_today = now - timedelta(
+            hours=now.hour, minutes=now.minute, seconds=now.second, microseconds=now.microsecond
+        )
+        start_of_yesterday = start_of_today - timedelta(days=1)
+
+        # Base filter conditions
+        base_filter = {
+            "success": True,
+            "status": True,
+        }
+
+        # Apply optional filters
+        if agent_id:
+            base_filter["agentId"] = agent_id
+
+        if function_name:
+            base_filter["functionName"] = {"in": function_name}
+
+        # Fetch successful triggers from the last day (excluding today)
+        last_day_successful_triggers = await self.db.prisma.triggerhistory.count(
+            where={**base_filter, "timestamp": {"gt": start_of_yesterday, "lt": start_of_today}}
+        )
+
+        # Fetch successful triggers from today
+        today_successful_triggers = await self.db.prisma.triggerhistory.count(
+            where={**base_filter, "timestamp": {"gt": start_of_today}}
+        )
+        return calculate_change_rate(last_day_successful_triggers, today_successful_triggers)


### PR DESCRIPTION
### Summary

The Trigger-Metric Service responsible for calculating the chart data previously was querying the whole TriggerHistory Table and filtering it afterwards which caused its response to be very slow. 

Improved the performance by refactoring the code to query / group the data by directly using SQL query. The service also supports filtering using agent_ID and function_names.