### PR TITLE
Feat/use same stake key for signup

### DIFF
--- a/api/backend/app/controllers/auth_router.py
+++ b/api/backend/app/controllers/auth_router.py
@@ -27,7 +27,12 @@ class AuthRouter(Routable):
 
             # Extract Signed Address and Creates a user using the address , if user with address already exists ,returns the user.
             signed_address = extract_signed_address_from_signature_header(hex_signature=signed_data.signature)
-            user = await self.user_service.create_user(UserCreateDto(address=signed_address, isSuperUser=False))
+
+            signed_address_without_network_prefix = signed_address[2:]
+
+            user = await self.user_service.create_user(
+                UserCreateDto(address=signed_address_without_network_prefix, isSuperUser=False)
+            )
 
             # Generate JWT Token using user Address
             token = generate_jwt_token_using_user_address(user.address)

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/frontend/src/components/Auth/WalletSignInDialog.tsx
+++ b/frontend/src/components/Auth/WalletSignInDialog.tsx
@@ -82,7 +82,8 @@ export default function WalletSignInDialog({
                 setCurrentConnectedWallet({
                     api: enabledWalletApi,
                     provider: wallet.name,
-                    address: stakeAddress,
+                    /* Store address without netowrk prefix */
+                    address: stakeAddress.slice(2, stakeAddress.length),
                     icon: wallet.icon
                 });
 


### PR DESCRIPTION
**Update to store Signed Address without network prefix**

**Issue :** When user changed the network from the same wallet different users were being generated. 

**Fix:** Fixed this issue by storing the address without prefix and also storing the address without prefix on the frontend.


**Caution** - After the merge of this feature users will lose access to their current agent , as new users will be created when they login without the network prefix address.