### PR TITLE
chore: add missing sub param name in form

### DIFF
--- a/frontend/src/app/(pages)/templates/create-template/components/trigger/ParameterRenderers.tsx
+++ b/frontend/src/app/(pages)/templates/create-template/components/trigger/ParameterRenderers.tsx
@@ -54,7 +54,10 @@ export const RenderObjectParameter = (
         <div className="ml-4 grid grid-cols-2 gap-4">
             {param.parameters?.map((subParam, subIndex) => (
                 <div key={subIndex} className="flex items-center gap-4">
-                    <Label className="h4 flex">{`Url${subParam.optional == false ? ' *' : ''}`}</Label>
+                    <Label className="h4 flex items-center">
+                        {subParam.name}
+                        {subParam.optional === false && <span className="ml-1">*</span>}
+                    </Label>
                     <Input
                         defaultValue={subParam.value}
                         className="w-full"


### PR DESCRIPTION
Minor Fix: Added Missing Sub-Parameter label in Function Form

The sub-parameter name in the function form was missing, so it has now been added to ensure correct functionality.