### PR TITLE
Add header-hash, block-no and slot-no in health response

### DIFF
--- a/dbsync-api/src/health/healthCheck.ts
+++ b/dbsync-api/src/health/healthCheck.ts
@@ -28,16 +28,21 @@ const getBlockInfo = async (req: Request, res: Response) => {
           "Unable to retrieve the latest block information from the database.",
       });
     }
-
-    const latestBlockTime = latestBlock.time.toISOString();
-    const timeDiff = secondsSince(latestBlockTime);
+    
+    const blockInfo = {
+      blockHash: latestBlock.hash.toString("hex"),
+      blockNo: latestBlock.block_no,
+      slotNo: latestBlock.slot_no?.toString(),
+      blockTime: latestBlock.time.toISOString(),
+    };
+    const timeDiff = secondsSince(blockInfo.blockTime);
 
     if (timeDiff > 300) {
       return res.status(503).json({
         status: "Service Unavailable",
         details: {
+          ...blockInfo,
           currentTime: new Date().toISOString(),
-          latestBlockTime,
           secondsSinceLastUpdate: timeDiff,
         },
       });
@@ -46,8 +51,8 @@ const getBlockInfo = async (req: Request, res: Response) => {
     return res.status(200).json({
       status: "Healthy",
       details: {
+        ...blockInfo,
         currentTime: new Date().toISOString(),
-        latestBlockTime,
         secondsSinceLastUpdate: timeDiff,
       },
     });

--- a/dbsync-api/swagger.yaml
+++ b/dbsync-api/swagger.yaml
@@ -486,11 +486,11 @@ paths:
           description: Internal server error
   /api/health:
     get:
-      summary: Check DBSync health status
-      description: Retrieves the latest block and checks if it was updated within the last 5 minutes.
+      summary: Health check for DBSync
+      description: Fetches the latest block information from the database and checks its freshness to determine the DBSync service's health.
       responses:
         '200':
-          description: DBSync service is healthy.
+          description: Service is healthy, and the latest block is up-to-date.
           content:
             application/json:
               schema:
@@ -502,19 +502,28 @@ paths:
                   details:
                     type: object
                     properties:
+                      blockHash:
+                        type: string
+                        example: "abcd1234ef5678..."
+                      blockNo:
+                        type: integer
+                        example: 123456
+                      slotNo:
+                        type: string
+                        example: "789012"
+                      blockTime:
+                        type: string
+                        format: date-time
+                        example: "2024-12-03T13:00:00Z"
                       currentTime:
                         type: string
                         format: date-time
-                        example: "2024-12-03T12:34:56.789Z"
-                      latestBlockTime:
-                        type: string
-                        format: date-time
-                        example: "2024-12-03T12:30:00.123Z"
+                        example: "2024-12-03T13:05:00Z"
                       secondsSinceLastUpdate:
                         type: number
-                        example: 296
+                        example: 300
         '503':
-          description: DBSync service is unavailable due to a delay in block updates.
+          description: The latest block has not been updated in over 300 seconds.
           content:
             application/json:
               schema:
@@ -526,19 +535,28 @@ paths:
                   details:
                     type: object
                     properties:
+                      blockHash:
+                        type: string
+                        example: "abcd1234ef5678..."
+                      blockNo:
+                        type: integer
+                        example: 123456
+                      slotNo:
+                        type: string
+                        example: "789012"
+                      blockTime:
+                        type: string
+                        format: date-time
+                        example: "2024-12-03T12:55:00Z"
                       currentTime:
                         type: string
                         format: date-time
-                        example: "2024-12-03T12:34:56.789Z"
-                      latestBlockTime:
-                        type: string
-                        format: date-time
-                        example: "2024-12-03T12:25:00.123Z"
+                        example: "2024-12-03T13:05:00Z"
                       secondsSinceLastUpdate:
                         type: number
-                        example: 596
+                        example: 600
         '500':
-          description: An error occurred while performing the health check.
+          description: An error occurred while processing the request.
           content:
             application/json:
               schema:


### PR DESCRIPTION
- Update response in `/api/health`
- example: 
  ```json
  {
    "status": "Healthy",
    "details": {
      "blockHash": "9986ba3e90af6d958f68f1ceadf0438f2113e63af78a6b4c3ecabe17cf21cab7",
      "blockNo": 2732207,
      "slotNo": "66561229",
      "blockTime": "2024-12-03T09:13:49.000Z",
      "currentTime": "2024-12-03T09:14:03.722Z",
      "secondsSinceLastUpdate": 14.722
    }
  }
  ```